### PR TITLE
manifest: reduce google.com permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
     "page": "app/background/background.html"
   },
   "options_page": "app/options/options.html",
-  "permissions": ["bookmarks", "chrome://favicon/", "fontSettings", "activeTab", "https://*.google.com/"]
+  "permissions": ["bookmarks", "chrome://favicon/", "fontSettings", "activeTab", "https://www.google.com/bookmarks/*"]
 }


### PR DESCRIPTION
Instead of requesting all of google.com settings (which can be a
bit confusing/scary for users), only request the bookmarks subpage
that we need.