### PR TITLE
no chrome update shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
         "128": "icons/icon-128.png"
     },
     "manifest_version": 3,
-    "minimum_chrome_version": "110",
+    "minimum_chrome_version": "1",
     "name": "Bookmarks Menu",
     "options_page": "app/options/options.html",
     "permissions": [


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)